### PR TITLE
Allow RoadRunner jobs to optionally forward a requestId as part of the task payload

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -7,6 +7,7 @@ namespace Shlinkio\Shlink\EventDispatcher;
 use Psr\Container\ContainerInterface;
 use Shlinkio\Shlink\EventDispatcher\Listener\DummyEnabledListenerChecker;
 use Shlinkio\Shlink\EventDispatcher\Listener\EnabledListenerCheckerInterface;
+use Shlinkio\Shlink\EventDispatcher\Util\RequestIdProviderInterface;
 use Spiral\RoadRunner\Jobs\JobsInterface;
 
 function lazyListener(ContainerInterface $container, string $listenerServiceName): callable
@@ -14,9 +15,12 @@ function lazyListener(ContainerInterface $container, string $listenerServiceName
     return new Listener\LazyEventListener($container, $listenerServiceName);
 }
 
-function roadRunnerTaskListener(JobsInterface $jobs, string $listenerServiceName): callable
-{
-    return new RoadRunner\RoadRunnerTaskListener($jobs, $listenerServiceName);
+function roadRunnerTaskListener(
+    JobsInterface $jobs,
+    string $listenerServiceName,
+    RequestIdProviderInterface $requestIdProvider,
+): callable {
+    return new RoadRunner\RoadRunnerTaskListener($jobs, $listenerServiceName, $requestIdProvider);
 }
 
 function resolveEnabledListenerChecker(ContainerInterface $container): EnabledListenerCheckerInterface

--- a/src/Listener/LazyEventListener.php
+++ b/src/Listener/LazyEventListener.php
@@ -6,12 +6,10 @@ namespace Shlinkio\Shlink\EventDispatcher\Listener;
 
 use Psr\Container\ContainerInterface;
 
-class LazyEventListener
+readonly class LazyEventListener
 {
-    public function __construct(
-        private readonly ContainerInterface $container,
-        private readonly string $listenerServiceName,
-    ) {
+    public function __construct(private ContainerInterface $container, private string $listenerServiceName)
+    {
     }
 
     public function __invoke(object $event): void

--- a/src/RoadRunner/RoadRunnerTaskConsumerToListener.php
+++ b/src/RoadRunner/RoadRunnerTaskConsumerToListener.php
@@ -23,7 +23,7 @@ readonly class RoadRunnerTaskConsumerToListener
     }
 
     /**
-     * @param callable(string): void|null $setCurrentRequestId
+     * @param (callable(string): void)|null $setCurrentRequestId
      */
     public function listenForTasks(?callable $setCurrentRequestId = null): void
     {
@@ -41,7 +41,7 @@ readonly class RoadRunnerTaskConsumerToListener
                 }
 
                 [
-                    'listenerServiceName' => $listener,
+                    'listenerServiceName' => $listenerService,
                     'eventPayload' => $payload,
                     'requestId' => $requestId,
                 ] = json_decode($task->getPayload());
@@ -49,7 +49,7 @@ readonly class RoadRunnerTaskConsumerToListener
                     $setCurrentRequestId($requestId);
                 }
 
-                $this->container->get($listener)($event::fromPayload($payload));
+                $this->container->get($listenerService)($event::fromPayload($payload));
                 $task->complete();
             } catch (Throwable $e) {
                 $task->fail($e);

--- a/src/RoadRunner/RoadRunnerTaskConsumerToListener.php
+++ b/src/RoadRunner/RoadRunnerTaskConsumerToListener.php
@@ -13,16 +13,19 @@ use Throwable;
 use function is_subclass_of;
 use function Shlinkio\Shlink\Json\json_decode;
 
-class RoadRunnerTaskConsumerToListener
+readonly class RoadRunnerTaskConsumerToListener
 {
     public function __construct(
-        private readonly ConsumerInterface $consumer,
-        private readonly ContainerInterface $container,
-        private readonly LoggerInterface $logger,
+        private ConsumerInterface $consumer,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
     ) {
     }
 
-    public function listenForTasks(): void
+    /**
+     * @param callable(string): void|null $setCurrentRequestId
+     */
+    public function listenForTasks(?callable $setCurrentRequestId = null): void
     {
         while ($task = $this->consumer->waitTask()) {
             try {
@@ -37,7 +40,15 @@ class RoadRunnerTaskConsumerToListener
                     continue;
                 }
 
-                ['listenerServiceName' => $listener, 'eventPayload' => $payload] = json_decode($task->getPayload());
+                [
+                    'listenerServiceName' => $listener,
+                    'eventPayload' => $payload,
+                    'requestId' => $requestId,
+                ] = json_decode($task->getPayload());
+                if ($setCurrentRequestId !== null) {
+                    $setCurrentRequestId($requestId);
+                }
+
                 $this->container->get($listener)($event::fromPayload($payload));
                 $task->complete();
             } catch (Throwable $e) {

--- a/src/RoadRunner/RoadRunnerTaskListener.php
+++ b/src/RoadRunner/RoadRunnerTaskListener.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\EventDispatcher\RoadRunner;
 
 use JsonSerializable;
+use Shlinkio\Shlink\EventDispatcher\Util\RequestIdProviderInterface;
 use Spiral\RoadRunner\Jobs\JobsInterface;
 
 use function Shlinkio\Shlink\Json\json_encode;
 
-class RoadRunnerTaskListener
+readonly class RoadRunnerTaskListener
 {
     private const SHLINK_QUEUE = 'shlink';
 
-    public function __construct(private readonly JobsInterface $jobs, private readonly string $listenerServiceName)
-    {
+    public function __construct(
+        private JobsInterface $jobs,
+        private string $listenerServiceName,
+        private RequestIdProviderInterface $requestIdProvider,
+    ) {
     }
 
     public function __invoke(object $event): void
@@ -23,6 +27,7 @@ class RoadRunnerTaskListener
         $task = $queue->create($event::class, json_encode([
             'listenerServiceName' => $this->listenerServiceName,
             'eventPayload' => $event instanceof JsonSerializable ? $event : [],
+            'requestId' => $this->requestIdProvider->currentRequestId(),
         ]));
         $queue->dispatch($task);
     }

--- a/src/Util/RequestIdProviderInterface.php
+++ b/src/Util/RequestIdProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\EventDispatcher\Util;
+
+interface RequestIdProviderInterface
+{
+    public function currentRequestId(): string;
+}

--- a/test/RoadRunner/RoadRunnerTaskConsumerToListenerTest.php
+++ b/test/RoadRunner/RoadRunnerTaskConsumerToListenerTest.php
@@ -66,6 +66,7 @@ class RoadRunnerTaskConsumerToListenerTest extends TestCase
         $task->method('getPayload')->willReturn(json_encode([
             'listenerServiceName' => 'my_listener',
             'eventPayload' => [],
+            'requestId' => '123',
         ]));
         $task->expects($this->once())->method('complete');
         $task->expects($this->never())->method('fail');
@@ -91,6 +92,7 @@ class RoadRunnerTaskConsumerToListenerTest extends TestCase
         $task->method('getPayload')->willReturn(json_encode([
             'listenerServiceName' => 'my_listener',
             'eventPayload' => [],
+            'requestId' => '123',
         ]));
         $task->expects($this->never())->method('complete');
         $task->expects($this->once())->method('fail')->with($this->isInstanceOf(RuntimeException::class));


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2049

Enhance roadrunner even listeners and dispatchers so that a request id can be forwarded via roadrunner task payload.